### PR TITLE
Fix MudSelect options rendering

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -4,7 +4,12 @@
 
 <MudPaper Class="pa-4">
     <MudTextField T="string" @bind-Value="_workflow.Name" Label="Workflow Name" Variant="Variant.Filled" Class="mb-2" />
-    <MudSelect T="string" @bind-Value="_workflow.Trigger.ActivityType" Label="Trigger" Variant="Variant.Filled" Class="mb-2" Items="_triggerOptions" />
+    <MudSelect T="string" @bind-Value="_workflow.Trigger.ActivityType" Label="Trigger" Variant="Variant.Filled" Class="mb-2">
+        @foreach (var option in _triggerOptions)
+        {
+            <MudSelectItem Value="@option">@option</MudSelectItem>
+        }
+    </MudSelect>
     <MudTextField T="string" @bind-Value="_workflow.Trigger.Condition" Label="Condition" Variant="Variant.Filled" Class="mb-4" />
 
     <MudDivider Class="mb-4" />
@@ -16,7 +21,14 @@
             <MudTh>Branches (IDs)</MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd><MudSelect T="string" @bind-Value="context.ActivityType" Items="_activityOptions" /></MudTd>
+            <MudTd>
+                <MudSelect T="string" @bind-Value="context.ActivityType">
+                    @foreach (var option in _activityOptions)
+                    {
+                        <MudSelectItem Value="@option">@option</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudTd>
             <MudTd><MudNumericField T="int?" @bind-Value="context.DelaySeconds" /></MudTd>
             <MudTd><MudTextField T="string" @bind-Value="context.Branches" /></MudTd>
         </RowTemplate>


### PR DESCRIPTION
## Summary
- Render trigger and activity options with explicit `MudSelectItem` elements

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5f0a91b4883299b29aed5c355312d