### PR TITLE
Show workflow diagram instead of JSON

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -75,13 +75,17 @@
     <MudButton OnClick="Generate" Variant="Variant.Filled" Color="Color.Secondary" StartIcon="@Icons.Material.Filled.Code" Class="mb-2">
         Generate JSON
     </MudButton>
-    <MudTextField T="string" @bind-Value="_json" Lines="10" ReadOnly="true" Class="mt-2" />
+    @if (_showDiagram)
+    {
+        <WorkflowDiagram Workflow="_workflow" />
+    }
 </MudCard>
 
 @code {
     protected WorkflowModel _workflow = new();
 
     protected string? _json;
+    protected bool _showDiagram;
 
     private readonly List<string> _triggerOptions = new() { "Start", "Schedule", "Signal" };
     private readonly List<string> _activityOptions = new() { "WriteLine", "SendEmail", "Delay" };
@@ -89,5 +93,9 @@
 
     void AddStep() => _workflow.Steps.Add(new StepModel());
 
-    void Generate() => _json = WorkflowService.GenerateJson(_workflow);
+    void Generate()
+    {
+        _json = WorkflowService.GenerateJson(_workflow);
+        _showDiagram = true;
+    }
 }

--- a/Shared/WorkflowDiagram.razor
+++ b/Shared/WorkflowDiagram.razor
@@ -1,0 +1,38 @@
+@using Microsoft.AspNetCore.Components
+@using BlazorWorkflowUI.Models
+
+<MudPaper Class="mt-2 pa-4">
+    <MudTimeline>
+        <MudTimelineItem Icon="@Icons.Material.Filled.PlayArrow">
+            <ChildContent>
+                <MudText>Trigger: @Workflow.Trigger.ActivityType (@Workflow.Trigger.Condition)</MudText>
+            </ChildContent>
+        </MudTimelineItem>
+        @foreach (var step in Workflow.Steps)
+        {
+            <MudTimelineItem Icon="@Icons.Material.Filled.ChevronRight">
+                <ChildContent>
+                    <MudText>@step.ActivityType</MudText>
+                    <MudText Typo="Typo.caption">Condition: @step.Condition</MudText>
+                    @if (step.ActivityType == "Delay")
+                    {
+                        <MudText Typo="Typo.caption">Delay: @step.DelaySeconds s</MudText>
+                    }
+                    @if (step.ElseActivityType != null)
+                    {
+                        <MudText Typo="Typo.caption">Else: @step.ElseActivityType</MudText>
+                        @if (step.ElseActivityType == "Delay")
+                        {
+                            <MudText Typo="Typo.caption">Else Delay: @step.ElseDelaySeconds s</MudText>
+                        }
+                    }
+                </ChildContent>
+            </MudTimelineItem>
+        }
+    </MudTimeline>
+</MudPaper>
+
+@code {
+    [Parameter]
+    public WorkflowModel Workflow { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
- replace JSON textbox with visual workflow diagram
- keep generated JSON internally while showing diagram after clicking Generate

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68a703ac45c88329b66dbb2426c7455a