### PR TITLE
feat: add insurance and mortgage workflow options

### DIFF
--- a/Models/WorkflowModel.cs
+++ b/Models/WorkflowModel.cs
@@ -9,16 +9,16 @@ public class WorkflowModel
 
 public class TriggerModel
 {
-    public string ActivityType { get; set; } = "Start";
-    public string Condition { get; set; } = "Always";
+    public string ActivityType { get; set; } = "PolicyCreated";
+    public string Condition { get; set; } = "NoCondition";
 }
 
 public class StepModel
 {
     public string Id { get; set; } = Guid.NewGuid().ToString();
-    public string ActivityType { get; set; } = "WriteLine";
+    public string ActivityType { get; set; } = "SendPolicyDocument";
     public int? DelaySeconds { get; set; }
-    public string Condition { get; set; } = "Always";
+    public string Condition { get; set; } = "NoCondition";
     public string? ElseActivityType { get; set; }
     public int? ElseDelaySeconds { get; set; }
 }

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -45,7 +45,7 @@
                 </MudSelect>
             </MudTd>
             <MudTd>
-                @if (context.ActivityType == "Delay")
+                @if (context.ActivityType == "WaitForDocuments")
                 {
                     <MudNumericField T="int?" @bind-Value="context.DelaySeconds" Label="Seconds" />
                 }
@@ -60,7 +60,7 @@
                 </MudSelect>
             </MudTd>
             <MudTd>
-                @if (context.ElseActivityType == "Delay")
+                @if (context.ElseActivityType == "WaitForDocuments")
                 {
                     <MudNumericField T="int?" @bind-Value="context.ElseDelaySeconds" Label="Seconds" />
                 }
@@ -87,9 +87,9 @@
     protected string? _json;
     protected bool _showDiagram;
 
-    private readonly List<string> _triggerOptions = new() { "Start", "Schedule", "Signal" };
-    private readonly List<string> _activityOptions = new() { "WriteLine", "SendEmail", "Delay" };
-    private readonly List<string> _conditionOptions = new() { "Always", "OnEvent", "OnData" };
+    private readonly List<string> _triggerOptions = new() { "PolicyCreated", "PremiumDue", "MortgageApplicationSubmitted" };
+    private readonly List<string> _activityOptions = new() { "SendPolicyDocument", "EvaluateMortgageApplication", "WaitForDocuments" };
+    private readonly List<string> _conditionOptions = new() { "NoCondition", "PolicyActive", "LoanApproved" };
 
     void AddStep() => _workflow.Steps.Add(new StepModel());
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # BlazorWorkflowUI
 
-A Blazor WebAssembly client application for building workflows in Elsa 3 JSON format. The UI uses [MudBlazor](https://mudblazor.com/) components (v6.11.2) to design workflows with triggers, optional conditions, steps, and delay activities.
+A Blazor WebAssembly client application for building workflows in Elsa 3 JSON format. The UI uses [MudBlazor](https://mudblazor.com/) components (v6.11.2) to design workflows with triggers, optional conditions, steps, and delay activities tailored for insurance and mortgage management.
 
 ## Features
-- Define workflow name, trigger, and condition.
-- Add multiple steps, including Delay steps.
+- Define workflow name, trigger, and condition with domain-specific options such as **PolicyCreated**, **PremiumDue**, and **MortgageApplicationSubmitted**.
+- Add multiple steps like **SendPolicyDocument**, **EvaluateMortgageApplication**, and **WaitForDocuments**.
 - Generate Elsa 3-like workflow JSON.
 
 ## Build

--- a/Services/WorkflowService.cs
+++ b/Services/WorkflowService.cs
@@ -15,7 +15,7 @@ public class WorkflowService : IWorkflowService
         {
             id = triggerId,
             type = workflow.Trigger.ActivityType,
-            condition = workflow.Trigger.Condition
+            condition = workflow.Trigger.Condition == "NoCondition" ? null : workflow.Trigger.Condition
         });
 
         var previousId = triggerId;
@@ -25,10 +25,10 @@ public class WorkflowService : IWorkflowService
             {
                 id = step.Id,
                 type = step.ActivityType,
-                delay = step.ActivityType == "Delay" ? step.DelaySeconds : null,
-                condition = step.Condition == "Always" ? null : step.Condition,
+                delay = step.ActivityType == "WaitForDocuments" ? step.DelaySeconds : null,
+                condition = step.Condition == "NoCondition" ? null : step.Condition,
                 elseType = step.ElseActivityType,
-                elseDelay = step.ElseActivityType == "Delay" ? step.ElseDelaySeconds : null
+                elseDelay = step.ElseActivityType == "WaitForDocuments" ? step.ElseDelaySeconds : null
             });
 
             connections.Add(new { source = previousId, target = step.Id });

--- a/Shared/WorkflowDiagram.razor
+++ b/Shared/WorkflowDiagram.razor
@@ -14,16 +14,16 @@
                 <ChildContent>
                     <MudText>@step.ActivityType</MudText>
                     <MudText Typo="Typo.caption">Condition: @step.Condition</MudText>
-                    @if (step.ActivityType == "Delay")
+                    @if (step.ActivityType == "WaitForDocuments")
                     {
-                        <MudText Typo="Typo.caption">Delay: @step.DelaySeconds s</MudText>
+                        <MudText Typo="Typo.caption">Wait: @step.DelaySeconds s</MudText>
                     }
                     @if (step.ElseActivityType != null)
                     {
                         <MudText Typo="Typo.caption">Else: @step.ElseActivityType</MudText>
-                        @if (step.ElseActivityType == "Delay")
+                        @if (step.ElseActivityType == "WaitForDocuments")
                         {
-                            <MudText Typo="Typo.caption">Else Delay: @step.ElseDelaySeconds s</MudText>
+                            <MudText Typo="Typo.caption">Else Wait: @step.ElseDelaySeconds s</MudText>
                         }
                     }
                 </ChildContent>


### PR DESCRIPTION
## Summary
- replace workflow trigger, activity, and condition options with insurance & mortgage specific choices
- add defaults and JSON generation logic for new options
- document new domain examples in README

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a7072e03f4832988e070a590a03747