### PR TITLE
Add branching component to improve workflow diagram readability

### DIFF
--- a/Shared/WorkflowBranch.razor
+++ b/Shared/WorkflowBranch.razor
@@ -1,0 +1,39 @@
+@using BlazorWorkflowUI.Models
+
+<MudPaper Class="pa-2 mt-2">
+    <MudText Typo="Typo.caption">Condition: @Step.Condition</MudText>
+    <MudGrid Class="mt-2">
+        <MudItem xs="5">
+            <div class="d-flex align-center">
+                <MudIcon Icon="@Icons.Material.Filled.Check" Color="Color.Success" Class="mr-1" />
+                <div>
+                    <MudText>@Step.ActivityType</MudText>
+                    @if (Step.ActivityType == "WaitForDocuments")
+                    {
+                        <MudText Typo="Typo.caption">Wait: @Step.DelaySeconds s</MudText>
+                    }
+                </div>
+            </div>
+        </MudItem>
+        <MudItem xs="2" Class="d-flex justify-center">
+            <MudDivider Vertical="true" />
+        </MudItem>
+        <MudItem xs="5">
+            <div class="d-flex align-center">
+                <MudIcon Icon="@Icons.Material.Filled.Close" Color="Color.Error" Class="mr-1" />
+                <div>
+                    <MudText>@Step.ElseActivityType</MudText>
+                    @if (Step.ElseActivityType == "WaitForDocuments")
+                    {
+                        <MudText Typo="Typo.caption">Wait: @Step.ElseDelaySeconds s</MudText>
+                    }
+                </div>
+            </div>
+        </MudItem>
+    </MudGrid>
+</MudPaper>
+
+@code {
+    [Parameter]
+    public StepModel Step { get; set; } = new();
+}

--- a/Shared/WorkflowDiagram.razor
+++ b/Shared/WorkflowDiagram.razor
@@ -12,32 +12,13 @@
         {
             <MudTimelineItem Icon="@Icons.Material.Filled.ChevronRight">
                 <ChildContent>
-                    <MudText Typo="Typo.caption">Condition: @step.Condition</MudText>
                     @if (step.ElseActivityType != null)
                     {
-                        <MudTimeline Dense="true" Class="ml-6">
-                            <MudTimelineItem Icon="@Icons.Material.Filled.Check">
-                                <ChildContent>
-                                    <MudText>@step.ActivityType</MudText>
-                                    @if (step.ActivityType == "WaitForDocuments")
-                                    {
-                                        <MudText Typo="Typo.caption">Wait: @step.DelaySeconds s</MudText>
-                                    }
-                                </ChildContent>
-                            </MudTimelineItem>
-                            <MudTimelineItem Icon="@Icons.Material.Filled.Close">
-                                <ChildContent>
-                                    <MudText>@step.ElseActivityType</MudText>
-                                    @if (step.ElseActivityType == "WaitForDocuments")
-                                    {
-                                        <MudText Typo="Typo.caption">Wait: @step.ElseDelaySeconds s</MudText>
-                                    }
-                                </ChildContent>
-                            </MudTimelineItem>
-                        </MudTimeline>
+                        <WorkflowBranch Step="step" />
                     }
                     else
                     {
+                        <MudText Typo="Typo.caption">Condition: @step.Condition</MudText>
                         <MudText>@step.ActivityType</MudText>
                         @if (step.ActivityType == "WaitForDocuments")
                         {


### PR DESCRIPTION
## Summary
- Add `WorkflowBranch` component to render conditional branches side-by-side for clear workflow splits.
- Update `WorkflowDiagram` to leverage new component when steps include an else activity.

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a7167d3960832987e13cbcc7652a10