### PR TITLE
Display trigger separately from workflow steps

### DIFF
--- a/Services/WorkflowService.cs
+++ b/Services/WorkflowService.cs
@@ -10,14 +10,7 @@ public class WorkflowService : IWorkflowService
         var activities = new List<object>();
         var connections = new List<object>();
 
-        var triggerId = "trigger";
-        activities.Add(new
-        {
-            id = triggerId,
-            type = workflow.Trigger.ActivityType
-        });
-
-        var previousId = triggerId;
+        string? previousId = null;
         foreach (var step in workflow.Steps)
         {
             activities.Add(new
@@ -30,11 +23,20 @@ public class WorkflowService : IWorkflowService
                 elseDelay = step.ElseActivityType == "WaitForDocuments" ? step.ElseDelaySeconds : null
             });
 
-            connections.Add(new { source = previousId, target = step.Id });
+            if (previousId != null)
+            {
+                connections.Add(new { source = previousId, target = step.Id });
+            }
             previousId = step.Id;
         }
 
-        var data = new { name = workflow.Name, activities, connections };
+        var data = new
+        {
+            name = workflow.Name,
+            trigger = workflow.Trigger.ActivityType,
+            activities,
+            connections
+        };
         return JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
     }
 }

--- a/Shared/WorkflowDiagram.razor
+++ b/Shared/WorkflowDiagram.razor
@@ -2,12 +2,8 @@
 @using BlazorWorkflowUI.Models
 
 <MudPaper Class="mt-2 pa-4">
+    <MudText Typo="Typo.subtitle1" Class="mb-2">Trigger: @Workflow.Trigger.ActivityType</MudText>
     <MudTimeline>
-        <MudTimelineItem Icon="@Icons.Material.Filled.PlayArrow">
-            <ChildContent>
-                <MudText>Trigger: @Workflow.Trigger.ActivityType</MudText>
-            </ChildContent>
-        </MudTimelineItem>
         @foreach (var step in Workflow.Steps)
         {
             <MudTimelineItem Icon="@Icons.Material.Filled.ChevronRight">


### PR DESCRIPTION
## Summary
- omit the trigger from workflow activities and connections while exposing it as its own property
- show the workflow trigger in a header and render only step items in the workflow timeline

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a723d6fe648329b3bb768acc13849e