### PR TITLE
feat: integrate step editing into workflow diagram

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -10,86 +10,24 @@
             <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
         }
     </MudSelect>
-
     <MudDivider Class="mb-4" />
-    <MudText Typo="Typo.h6" Class="mb-2">Steps</MudText>
-    <MudTable Items="_workflow.Steps" Class="mb-2" Dense="true">
-        <HeaderContent>
-            <MudTh>Condition</MudTh>
-            <MudTh>Match Activity</MudTh>
-            <MudTh>Match Details</MudTh>
-            <MudTh>No Match Activity</MudTh>
-            <MudTh>No Match Details</MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd>
-                <MudSelect T="string" @bind-Value="context.Condition">
-                    @foreach (var option in _conditionOptions)
-                    {
-                        <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
-                    }
-                </MudSelect>
-            </MudTd>
-            <MudTd>
-                <MudSelect T="string" @bind-Value="context.ActivityType">
-                    @foreach (var option in _activityOptions)
-                    {
-                        <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
-                    }
-                </MudSelect>
-            </MudTd>
-            <MudTd>
-                @if (context.ActivityType == "WaitForDocuments")
-                {
-                    <MudNumericField T="int?" @bind-Value="context.DelaySeconds" Label="Seconds" />
-                }
-            </MudTd>
-            <MudTd>
-                <MudSelect T="string" @bind-Value="context.ElseActivityType">
-                    <MudSelectItem T="string" Value="@null">None</MudSelectItem>
-                    @foreach (var option in _activityOptions)
-                    {
-                        <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
-                    }
-                </MudSelect>
-            </MudTd>
-            <MudTd>
-                @if (context.ElseActivityType == "WaitForDocuments")
-                {
-                    <MudNumericField T="int?" @bind-Value="context.ElseDelaySeconds" Label="Seconds" />
-                }
-            </MudTd>
-        </RowTemplate>
-    </MudTable>
-    <MudButton OnClick="AddStep" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add" Class="mb-4">
-        Add Step
-    </MudButton>
-
+    <SimpleWorkflowDiagram Workflow="_workflow" ActivityOptions="_activityOptions" ConditionOptions="_conditionOptions" />
     <MudDivider Class="mb-4" />
     <MudButton OnClick="Generate" Variant="Variant.Filled" Color="Color.Secondary" StartIcon="@Icons.Material.Filled.Code" Class="mb-2">
         Generate
     </MudButton>
-    @if (_showDiagram)
-    {
-        <SimpleWorkflowDiagram Workflow="_workflow" />
-    }
 </MudContainer>
 
 @code {
     protected WorkflowModel _workflow = new();
 
     protected string? _json;
-    protected bool _showDiagram;
-
     private readonly List<string> _triggerOptions = new() { "PolicyCreated", "PremiumDue", "MortgageApplicationSubmitted" };
     private readonly List<string> _activityOptions = new() { "SendPolicyDocument", "EvaluateMortgageApplication", "WaitForDocuments" };
     private readonly List<string> _conditionOptions = new() { "NoCondition", "PolicyActive", "LoanApproved" };
 
-    void AddStep() => _workflow.Steps.Add(new StepModel());
-
     void Generate()
     {
         _json = WorkflowService.GenerateJson(_workflow);
-        _showDiagram = true;
     }
 }

--- a/Shared/SimpleWorkflowDiagram.razor
+++ b/Shared/SimpleWorkflowDiagram.razor
@@ -1,3 +1,4 @@
+@using System.Linq
 @using BlazorWorkflowUI.Models
 
 <div class="workflow-diagram">
@@ -7,16 +8,28 @@
         <div class="arrow">&#8595;</div>
         if (step.ElseActivityType != null)
         {
-            <div class="activity-box">Condition: @step.Condition</div>
+            <div class="activity-box">
+                <MudSelect T="string" @bind-Value="step.Condition" Dense="true">
+                    @foreach (var option in ConditionOptions)
+                    {
+                        <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
             <div class="branches">
                 <div class="branch">
                     <div class="arrow">&#8601;</div>
                     <div class="branch-label">Match</div>
                     <div class="activity-box">
-                        @step.ActivityType
+                        <MudSelect T="string" @bind-Value="step.ActivityType" Dense="true">
+                            @foreach (var option in ActivityOptions)
+                            {
+                                <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
+                            }
+                        </MudSelect>
                         @if (step.ActivityType == "WaitForDocuments")
                         {
-                            <div class="details">Wait: @step.DelaySeconds s</div>
+                            <MudNumericField T="int?" @bind-Value="step.DelaySeconds" Label="Seconds" Dense="true" />
                         }
                     </div>
                 </div>
@@ -24,10 +37,16 @@
                     <div class="arrow">&#8600;</div>
                     <div class="branch-label">No Match</div>
                     <div class="activity-box">
-                        @step.ElseActivityType
+                        <MudSelect T="string" @bind-Value="step.ElseActivityType" Dense="true">
+                            <MudSelectItem T="string" Value="@null">None</MudSelectItem>
+                            @foreach (var option in ActivityOptions)
+                            {
+                                <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
+                            }
+                        </MudSelect>
                         @if (step.ElseActivityType == "WaitForDocuments")
                         {
-                            <div class="details">Wait: @step.ElseDelaySeconds s</div>
+                            <MudNumericField T="int?" @bind-Value="step.ElseDelaySeconds" Label="Seconds" Dense="true" />
                         }
                     </div>
                 </div>
@@ -36,15 +55,30 @@
         else
         {
             <div class="activity-box">
-                <div>Condition: @step.Condition</div>
-                <div>@step.ActivityType</div>
+                <MudSelect T="string" @bind-Value="step.Condition" Dense="true">
+                    @foreach (var option in ConditionOptions)
+                    {
+                        <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
+                    }
+                </MudSelect>
+                <MudSelect T="string" @bind-Value="step.ActivityType" Dense="true">
+                    @foreach (var option in ActivityOptions)
+                    {
+                        <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
+                    }
+                </MudSelect>
                 @if (step.ActivityType == "WaitForDocuments")
                 {
-                    <div class="details">Wait: @step.DelaySeconds s</div>
+                    <MudNumericField T="int?" @bind-Value="step.DelaySeconds" Label="Seconds" Dense="true" />
                 }
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="@(() => step.ElseActivityType = ActivityOptions.First())">
+                    Add Branch
+                </MudButton>
             </div>
         }
     }
+    <div class="arrow">&#8595;</div>
+    <MudButton OnClick="AddStep" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add">Add Step</MudButton>
 </div>
 
 <style>
@@ -89,4 +123,13 @@
 @code {
     [Parameter]
     public WorkflowModel Workflow { get; set; } = new();
+
+    [Parameter]
+    public List<string> ActivityOptions { get; set; } = new();
+
+    [Parameter]
+    public List<string> ConditionOptions { get; set; } = new();
+
+    void AddStep() => Workflow.Steps.Add(new StepModel());
 }
+


### PR DESCRIPTION
## Summary
- embed interactive workflow diagram directly on the index page
- allow editing step details, branches, and adding steps inside the diagram

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a74349fa108329b527c499df5a5390