### PR TITLE
Move trigger selection into workflow control

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -4,14 +4,8 @@
 
 <MudContainer Class="pa-4 mx-auto my-4" >
     <MudTextField T="string" @bind-Value="_workflow.Name" Label="Workflow Name" Variant="Variant.Filled" Class="mb-3" />
-    <MudSelect T="string" @bind-Value="_workflow.Trigger.ActivityType" Label="Trigger" Variant="Variant.Filled" Class="mb-4">
-        @foreach (var option in _triggerOptions)
-        {
-            <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
-        }
-    </MudSelect>
     <MudDivider Class="mb-4" />
-    <SimpleWorkflowDiagram Workflow="_workflow" ActivityOptions="_activityOptions" ConditionOptions="_conditionOptions" />
+    <SimpleWorkflowDiagram Workflow="_workflow" ActivityOptions="_activityOptions" ConditionOptions="_conditionOptions" TriggerOptions="_triggerOptions" />
     <MudDivider Class="mb-4" />
     <MudButton OnClick="Generate" Variant="Variant.Filled" Color="Color.Secondary" StartIcon="@Icons.Material.Filled.Code" Class="mb-2">
         Generate

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Blazor WebAssembly client application for building workflows in Elsa 3 JSON format. The UI uses [MudBlazor](https://mudblazor.com/) components (v6.11.2) to design workflows with triggers, steps with optional conditions, and delay activities tailored for insurance and mortgage management.
 
 ## Features
-- Define workflow name and trigger with domain-specific options such as **PolicyCreated**, **PremiumDue**, and **MortgageApplicationSubmitted**.
+- Define workflow name and select triggers within the workflow diagram using domain-specific options such as **PolicyCreated**, **PremiumDue**, and **MortgageApplicationSubmitted**.
 - Add multiple steps like **SendPolicyDocument**, **EvaluateMortgageApplication**, and **WaitForDocuments**, each with optional conditions.
 - Generate Elsa 3-like workflow JSON.
 

--- a/Shared/SimpleWorkflowDiagram.razor
+++ b/Shared/SimpleWorkflowDiagram.razor
@@ -2,7 +2,14 @@
 @using BlazorWorkflowUI.Models
 
 <div class="workflow-diagram">
-    <div class="activity-box">Trigger: @Workflow.Trigger.ActivityType</div>
+    <div class="activity-box">
+        <MudSelect T="string" @bind-Value="Workflow.Trigger.ActivityType" Label="Trigger" Dense="true">
+            @foreach (var option in TriggerOptions)
+            {
+                <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
+            }
+        </MudSelect>
+    </div>
     @foreach (var step in Workflow.Steps)
     {
         <div class="arrow">&#8595;</div>
@@ -129,6 +136,9 @@
 
     [Parameter]
     public List<string> ConditionOptions { get; set; } = new();
+
+    [Parameter]
+    public List<string> TriggerOptions { get; set; } = new();
 
     void AddStep() => Workflow.Steps.Add(new StepModel());
 }


### PR DESCRIPTION
## Summary
- Embed trigger selection inside workflow diagram component
- Simplify index page by removing top-level trigger dropdown
- Document trigger selection location in README

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not accessible)*

------
https://chatgpt.com/codex/tasks/task_b_68a74885fcc88329b9a0e07bc0d1317c