### PR TITLE
Add in-memory save and load for workflow tasks

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -7,9 +7,11 @@
     <MudDivider Class="mb-4" />
     <SimpleWorkflowDiagram Workflow="_workflow" ActivityOptions="_activityOptions" ConditionOptions="_conditionOptions" TriggerOptions="_triggerOptions" />
     <MudDivider Class="mb-4" />
-    <MudButton OnClick="Generate" Variant="Variant.Filled" Color="Color.Secondary" StartIcon="@Icons.Material.Filled.Code" Class="mb-2">
-        Generate
-    </MudButton>
+    <MudStack Direction="Row" Spacing="1" Class="mb-2">
+        <MudButton OnClick="Save" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Save">Save</MudButton>
+        <MudButton OnClick="Load" Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.FolderOpen">Load</MudButton>
+        <MudButton OnClick="Generate" Variant="Variant.Filled" Color="Color.Secondary" StartIcon="@Icons.Material.Filled.Code">Generate</MudButton>
+    </MudStack>
 </MudContainer>
 
 @code {
@@ -23,5 +25,19 @@
     void Generate()
     {
         _json = WorkflowService.GenerateJson(_workflow);
+    }
+
+    void Save()
+    {
+        WorkflowService.Save(_workflow);
+    }
+
+    void Load()
+    {
+        var loaded = WorkflowService.Load(_workflow.Name);
+        if (loaded is not null)
+        {
+            _workflow = loaded;
+        }
     }
 }

--- a/Services/IWorkflowService.cs
+++ b/Services/IWorkflowService.cs
@@ -5,4 +5,6 @@ namespace BlazorWorkflowUI.Services;
 public interface IWorkflowService
 {
     string GenerateJson(WorkflowModel workflow);
+    void Save(WorkflowModel workflow);
+    WorkflowModel? Load(string name);
 }

--- a/Services/WorkflowService.cs
+++ b/Services/WorkflowService.cs
@@ -5,6 +5,8 @@ namespace BlazorWorkflowUI.Services;
 
 public class WorkflowService : IWorkflowService
 {
+    private readonly Dictionary<string, WorkflowModel> _store = new();
+
     public string GenerateJson(WorkflowModel workflow)
     {
         var activities = new List<object>();
@@ -54,5 +56,21 @@ public class WorkflowService : IWorkflowService
             connections
         };
         return JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    public void Save(WorkflowModel workflow)
+    {
+        _store[workflow.Name] = Clone(workflow);
+    }
+
+    public WorkflowModel? Load(string name)
+    {
+        return _store.TryGetValue(name, out var workflow) ? Clone(workflow) : null;
+    }
+
+    private static WorkflowModel Clone(WorkflowModel workflow)
+    {
+        var json = JsonSerializer.Serialize(workflow);
+        return JsonSerializer.Deserialize<WorkflowModel>(json) ?? new WorkflowModel();
     }
 }


### PR DESCRIPTION
## Summary
- add in-memory store for workflow tasks
- allow saving and loading workflows by name
- expose save/load actions in UI so tasks can be edited after loading

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a823983a9c832990257ce5eace4ce3