### PR TITLE
Allow text and file attachments for workflow steps

### DIFF
--- a/Models/WorkflowModel.cs
+++ b/Models/WorkflowModel.cs
@@ -20,4 +20,15 @@ public class StepModel
     public string Condition { get; set; } = "NoCondition";
     public string? ElseActivityType { get; set; }
     public int? ElseDelaySeconds { get; set; }
+    public string? Text { get; set; }
+    public List<StepAttachmentModel> Attachments { get; set; } = new();
+    public string? ElseText { get; set; }
+    public List<StepAttachmentModel> ElseAttachments { get; set; } = new();
+}
+
+public class StepAttachmentModel
+{
+    public string FileName { get; set; } = string.Empty;
+    public string ContentType { get; set; } = string.Empty;
+    public byte[] Data { get; set; } = Array.Empty<byte>();
 }

--- a/Services/WorkflowService.cs
+++ b/Services/WorkflowService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BlazorWorkflowUI.Models;
+using System.Linq;
 
 namespace BlazorWorkflowUI.Services;
 
@@ -21,7 +22,9 @@ public class WorkflowService : IWorkflowService
                 id = step.Id,
                 type = step.ActivityType,
                 delay = step.ActivityType == "WaitForDocuments" ? step.DelaySeconds : null,
-                condition = step.Condition == "NoCondition" ? null : step.Condition
+                condition = step.Condition == "NoCondition" ? null : step.Condition,
+                text = step.Text,
+                files = step.Attachments.Select(a => new { name = a.FileName, contentType = a.ContentType, data = Convert.ToBase64String(a.Data) })
             });
 
             if (previousId != null)
@@ -36,7 +39,9 @@ public class WorkflowService : IWorkflowService
                 {
                     id = elseId,
                     type = step.ElseActivityType,
-                    delay = step.ElseActivityType == "WaitForDocuments" ? step.ElseDelaySeconds : null
+                    delay = step.ElseActivityType == "WaitForDocuments" ? step.ElseDelaySeconds : null,
+                    text = step.ElseText,
+                    files = step.ElseAttachments.Select(a => new { name = a.FileName, contentType = a.ContentType, data = Convert.ToBase64String(a.Data) })
                 });
 
                 if (previousId != null)

--- a/Shared/SimpleWorkflowDiagram.razor
+++ b/Shared/SimpleWorkflowDiagram.razor
@@ -1,5 +1,6 @@
 @using System.Linq
 @using BlazorWorkflowUI.Models
+@using Microsoft.AspNetCore.Components.Forms
 
 <div class="workflow-diagram">
     <div class="activity-box">
@@ -38,6 +39,17 @@
                         {
                             <MudNumericField T="int?" @bind-Value="step.DelaySeconds" Label="Seconds" Dense="true" />
                         }
+                        <MudTextField T="string" @bind-Value="step.Text" Label="Text" Lines="3" Dense="true" />
+                        <InputFile OnChange="@(e => UploadFiles(e, step))" multiple accept="application/pdf,image/*,video/*,audio/*" />
+                        @if (step.Attachments.Any())
+                        {
+                            <ul class="attachment-list">
+                                @foreach (var file in step.Attachments)
+                                {
+                                    <li>@file.FileName <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="@(() => RemoveFile(step, file))" /></li>
+                                }
+                            </ul>
+                        }
                     </div>
                 </div>
                 <div class="branch">
@@ -54,6 +66,17 @@
                         @if (step.ElseActivityType == "WaitForDocuments")
                         {
                             <MudNumericField T="int?" @bind-Value="step.ElseDelaySeconds" Label="Seconds" Dense="true" />
+                        }
+                        <MudTextField T="string" @bind-Value="step.ElseText" Label="Text" Lines="3" Dense="true" />
+                        <InputFile OnChange="@(e => UploadFiles(e, step, true))" multiple accept="application/pdf,image/*,video/*,audio/*" />
+                        @if (step.ElseAttachments.Any())
+                        {
+                            <ul class="attachment-list">
+                                @foreach (var file in step.ElseAttachments)
+                                {
+                                    <li>@file.FileName <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="@(() => RemoveFile(step, file, true))" /></li>
+                                }
+                            </ul>
                         }
                     </div>
                 </div>
@@ -77,6 +100,17 @@
                 @if (step.ActivityType == "WaitForDocuments")
                 {
                     <MudNumericField T="int?" @bind-Value="step.DelaySeconds" Label="Seconds" Dense="true" />
+                }
+                <MudTextField T="string" @bind-Value="step.Text" Label="Text" Lines="3" Dense="true" />
+                <InputFile OnChange="@(e => UploadFiles(e, step))" multiple accept="application/pdf,image/*,video/*,audio/*" />
+                @if (step.Attachments.Any())
+                {
+                    <ul class="attachment-list">
+                        @foreach (var file in step.Attachments)
+                        {
+                            <li>@file.FileName <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="@(() => RemoveFile(step, file))" /></li>
+                        }
+                    </ul>
                 }
                 <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="@(() => step.ElseActivityType = ActivityOptions.First())">
                     Add Branch
@@ -128,6 +162,17 @@
     font-size: 0.8em;
     color: #666;
 }
+.attachment-list {
+    list-style-type: none;
+    padding-left: 0;
+    margin-top: 4px;
+}
+.attachment-list li {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+}
 </style>
 
 @code {
@@ -145,5 +190,39 @@
 
     void AddStep() => Workflow.Steps.Add(new StepModel());
     void RemoveStep(StepModel step) => Workflow.Steps.Remove(step);
+    async Task UploadFiles(InputFileChangeEventArgs e, StepModel step, bool isElse = false)
+    {
+        foreach (var file in e.GetMultipleFiles())
+        {
+            var buffer = new byte[file.Size];
+            await file.OpenReadStream(10_000_000).ReadAsync(buffer);
+            var attachment = new StepAttachmentModel
+            {
+                FileName = file.Name,
+                ContentType = file.ContentType,
+                Data = buffer
+            };
+            if (isElse)
+            {
+                step.ElseAttachments.Add(attachment);
+            }
+            else
+            {
+                step.Attachments.Add(attachment);
+            }
+        }
+    }
+
+    void RemoveFile(StepModel step, StepAttachmentModel file, bool isElse = false)
+    {
+        if (isElse)
+        {
+            step.ElseAttachments.Remove(file);
+        }
+        else
+        {
+            step.Attachments.Remove(file);
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- support storing text and file attachments on workflow steps
- expose text entry and file upload for both match and no-match branches in the workflow editor
- include step text and attachments when generating workflow JSON

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a872c433208329b3608bed61962625