### PR TITLE
Sync TimeSpanInput controls with bound value

### DIFF
--- a/Shared/TimeSpanInput.razor
+++ b/Shared/TimeSpanInput.razor
@@ -10,11 +10,41 @@
 @code {
     private int _amount;
     private string _unit = "Minutes";
+    private string? _lastValue;
 
     [Parameter] public string? Value { get; set; }
     [Parameter] public EventCallback<string?> ValueChanged { get; set; }
 
-    protected override Task OnInitializedAsync() => UpdateValue();
+    protected override void OnParametersSet()
+    {
+        if (_lastValue != Value)
+        {
+            _lastValue = Value;
+            if (Value != null && TimeSpan.TryParse(Value, out var ts))
+            {
+                if (ts.TotalDays >= 1 && ts.TotalDays % 1 == 0)
+                {
+                    _unit = "Days";
+                    _amount = (int)ts.TotalDays;
+                }
+                else if (ts.TotalHours >= 1 && ts.TotalHours % 1 == 0)
+                {
+                    _unit = "Hours";
+                    _amount = (int)ts.TotalHours;
+                }
+                else
+                {
+                    _unit = "Minutes";
+                    _amount = (int)ts.TotalMinutes;
+                }
+            }
+            else
+            {
+                _unit = "Minutes";
+                _amount = 0;
+            }
+        }
+    }
 
     private Task OnAmountChanged(int value)
     {
@@ -38,6 +68,7 @@
             _ => TimeSpan.Zero
         };
         Value = ts.ToString();
+        _lastValue = Value;
         return ValueChanged.InvokeAsync(Value);
     }
 }


### PR DESCRIPTION
## Summary
- Sync `TimeSpanInput` controls from the bound value and track last value to avoid overriding user choices

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b80b40a41c83299b2f828789aa1ec0