### PR TITLE
Initialize TimeSpanInput from initial value

### DIFF
--- a/Shared/TimeSpanInput.razor
+++ b/Shared/TimeSpanInput.razor
@@ -15,34 +15,45 @@
     [Parameter] public string? Value { get; set; }
     [Parameter] public EventCallback<string?> ValueChanged { get; set; }
 
+    protected override void OnInitialized()
+    {
+        UpdateFromValue();
+        _lastValue = Value;
+    }
+
     protected override void OnParametersSet()
     {
         if (_lastValue != Value)
         {
             _lastValue = Value;
-            if (Value != null && TimeSpan.TryParse(Value, out var ts))
+            UpdateFromValue();
+        }
+    }
+
+    private void UpdateFromValue()
+    {
+        if (Value != null && TimeSpan.TryParse(Value, out var ts))
+        {
+            if (ts.TotalDays >= 1 && ts.TotalDays % 1 == 0)
             {
-                if (ts.TotalDays >= 1 && ts.TotalDays % 1 == 0)
-                {
-                    _unit = "Days";
-                    _amount = (int)ts.TotalDays;
-                }
-                else if (ts.TotalHours >= 1 && ts.TotalHours % 1 == 0)
-                {
-                    _unit = "Hours";
-                    _amount = (int)ts.TotalHours;
-                }
-                else
-                {
-                    _unit = "Minutes";
-                    _amount = (int)ts.TotalMinutes;
-                }
+                _unit = "Days";
+                _amount = (int)ts.TotalDays;
+            }
+            else if (ts.TotalHours >= 1 && ts.TotalHours % 1 == 0)
+            {
+                _unit = "Hours";
+                _amount = (int)ts.TotalHours;
             }
             else
             {
                 _unit = "Minutes";
-                _amount = 0;
+                _amount = (int)ts.TotalMinutes;
             }
+        }
+        else
+        {
+            _unit = "Minutes";
+            _amount = 0;
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure TimeSpanInput initializes its controls from the provided value
- refactor parsing logic into helper method

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b810be78008329aa406ef075d01f01