### PR TITLE
Improve layout and add theme toggle for modern UI

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -2,15 +2,17 @@
 
 @inject IWorkflowService WorkflowService
 
-<MudContainer Class="pa-4 mx-auto my-4" >
-    <MudTextField T="string" @bind-Value="_workflow.Name" Label="Workflow Name" Variant="Variant.Filled" Class="mb-3" />
-    <MudDivider Class="mb-4" />
-    <SimpleWorkflowDiagram Workflow="_workflow" ActivityOptions="_activityOptions" ConditionOptions="_conditionOptions" TriggerOptions="_triggerOptions" />
-    <MudDivider Class="mb-4" />
-    <MudStack Direction="Row" Spacing="1" Class="mb-2">
-        <MudButton OnClick="Save" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Save">Save</MudButton>
-        <MudButton OnClick="Load" Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.FolderOpen">Load</MudButton>
-    </MudStack>
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mx-auto my-4">
+    <MudPaper Class="p-6">
+        <MudTextField T="string" @bind-Value="_workflow.Name" Label="Workflow Name" Placeholder="Enter a workflow name" Variant="Variant.Filled" Class="mb-4" />
+        <MudDivider Class="my-4" />
+        <SimpleWorkflowDiagram Workflow="_workflow" ActivityOptions="_activityOptions" ConditionOptions="_conditionOptions" TriggerOptions="_triggerOptions" />
+        <MudDivider Class="my-4" />
+        <MudStack Direction="Row" Spacing="1" Justify="flex-end">
+            <MudButton OnClick="Save" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Save">Save</MudButton>
+            <MudButton OnClick="Load" Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.FolderOpen">Load</MudButton>
+        </MudStack>
+    </MudPaper>
 </MudContainer>
 
 @code {

--- a/Shared/MainLayout.razor
+++ b/Shared/MainLayout.razor
@@ -1,14 +1,21 @@
 @inherits LayoutComponentBase
 
-<MudThemeProvider />
+<MudThemeProvider @bind-IsDarkMode="_isDarkMode" />
 <MudDialogProvider />
 <MudSnackbarProvider />
 
 <MudLayout>
     <MudAppBar Color="Color.Primary" Elevation="1">
         <MudText Typo="Typo.h6">Workflow Designer</MudText>
+        <MudSpacer />
+        <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)" Color="Color.Inherit" OnClick="ToggleDarkMode" />
     </MudAppBar>
     <MudMainContent>
         @Body
     </MudMainContent>
 </MudLayout>
+
+@code {
+    private bool _isDarkMode;
+    void ToggleDarkMode() => _isDarkMode = !_isDarkMode;
+}

--- a/Shared/SimpleWorkflowDiagram.razor
+++ b/Shared/SimpleWorkflowDiagram.razor
@@ -3,8 +3,8 @@
 @using BlazorWorkflowUI.Models
 @using Microsoft.AspNetCore.Components.Forms
 
-<div class="workflow-diagram">
-    <div class="activity-box">
+<MudStack Class="workflow-diagram" AlignItems="AlignItems.Center" Spacing="2">
+    <MudPaper Class="activity-box p-4">
         <MudSelect T="string" @bind-Value="Workflow.Trigger.ActivityType" Label="Trigger" Dense="true">
             @foreach (var option in TriggerOptions)
             {
@@ -17,11 +17,11 @@
                 <MudSelectItem T="string" Value="@option">@option</MudSelectItem>
             }
         </MudSelect>
-    </div>
+    </MudPaper>
     @foreach (var step in Workflow.Steps)
     {
-        <div class="arrow">&#8595;</div>
-        <div class="activity-box">
+        <MudIcon Icon="@Icons.Material.Filled.ArrowDownward" Class="arrow" />
+        <MudPaper Class="activity-box p-4">
             <MudSelect T="string" @bind-Value="step.ActivityType" Dense="true">
                 @foreach (var option in ActivityOptions)
                 {
@@ -80,11 +80,11 @@
                 </MudSelect>
             }
             <MudButton Variant="Variant.Text" Color="Color.Error" StartIcon="@Icons.Material.Filled.Delete" OnClick="@(() => RemoveStep(step))">Remove Step</MudButton>
-        </div>
+        </MudPaper>
     }
-    <div class="arrow">&#8595;</div>
+    <MudIcon Icon="@Icons.Material.Filled.ArrowDownward" Class="arrow" />
     <MudButton OnClick="AddStep" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add">Add Step</MudButton>
-</div>
+</MudStack>
 
 <style>
 .workflow-diagram {
@@ -93,11 +93,6 @@
     align-items: center;
 }
 .activity-box {
-    border: 1px solid #ccc;
-    padding: 8px;
-    margin: 4px;
-    border-radius: 4px;
-    background-color: #f9f9f9;
     min-width: 200px;
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- Add dark/light mode toggle to app bar for theme switching
- Wrap workflow editor in a centered card with clearer actions
- Modernize workflow diagram layout using MudBlazor components

## Testing
- ⚠️ `dotnet build` *(command not found; attempted apt-get install but repository access was forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68bad94e78948329b539160c51b9cb64